### PR TITLE
migrate to @ungap/event-target

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,11 @@
 /* eslint-disable func-names, func-name-matching */
 
-var EventTarget = require('event-target');
+var EventTarget = require('@ungap/event-target');
 
 var assign = Object.assign || require('object.assign');
 var StorageEvent = require('./event').StorageEvent;
 
-/**
- *  Create window as event target
- */
-function Window() {}
-Window.prototype.addEventListener = EventTarget.addEventListener;
-Window.prototype.removeEventListener = EventTarget.removeEventListener;
-Window.prototype.dispatchEvent = EventTarget.dispatchEvent;
-
-var window = new Window();
+var window = new EventTarget();
 
 /**
  * Mocked storage (initially borrowed from https://github.com/azu/mock-localstorage)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "events"
   ],
   "dependencies": {
-    "event-target": "^0.1.0",
+    "@ungap/event-target": "^0.2.2",
     "object.assign": "^4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
from NPM warning:

```
npm WARN deprecated event-target@0.1.0: improved, moved, and maintained as @ungap/event-target
```